### PR TITLE
Add ability to format JSON timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following examples highlight different ways that the plugin can be used.  Si
 
 ### Example 1
 
-The goal in this example is to send all HTTP and DNS records to a Kafka topic named `bro`. 
+The goal in this example is to send all HTTP and DNS records to a Kafka topic named `bro`.
  * Any configuration value accepted by librdkafka can be added to the `kafka_conf` configuration table.  
  * By defining `topic_name` all records will be sent to the same Kafka topic.
  * Defining `logs_to_send` will ensure that only HTTP and DNS records are sent.
@@ -185,6 +185,15 @@ example, a Conn::LOG message will look like `{ 'conn' : { ... }}`.
 
 ```
 redef Kafka::tag_json = T;
+```
+
+### `json_timestamps`
+
+Uses Ascii log writer for timestamp format. Default is `JSON::TS_EPOCH`. Other
+options are `JSON::TS_MILLIS` and `JSON::TS_ISO8601`.
+
+```
+redef Kafka::json_timestamps = JSON::TS_ISO8601;
 ```
 
 ### `debug`

--- a/scripts/Apache/Kafka/logs-to-kafka.bro
+++ b/scripts/Apache/Kafka/logs-to-kafka.bro
@@ -19,8 +19,8 @@
 module Kafka;
 
 export {
-	##
-	## which log streams should be sent to kafka?
+	## Specify a set of logs to send by log id. An empty set will
+	## default to all logs being sent.
 	## example:
 	##		redef Kafka::logs_to_send = set(Conn::Log, HTTP::LOG, DNS::LOG);
 	##
@@ -31,7 +31,7 @@ event bro_init() &priority=-5
 {
 	for (stream_id in Log::active_streams)
 	{
-		if (stream_id in Kafka::logs_to_send)
+		if ( (|logs_to_send| == 0) || stream_id in Kafka::logs_to_send )
 		{
 			local filter: Log::Filter = [
 				$name = fmt("kafka-%s", stream_id),

--- a/scripts/Bro/Kafka/logs-to-kafka.bro
+++ b/scripts/Bro/Kafka/logs-to-kafka.bro
@@ -19,8 +19,8 @@
 module Kafka;
 
 export {
-	##
-	## which log streams should be sent to kafka?
+	## Specify a set of logs to send by log id. An empty set will
+	## default to all logs being sent.
 	## example:
 	##		redef Kafka::logs_to_send = set(Conn::Log, HTTP::LOG, DNS::LOG);
 	##
@@ -31,7 +31,7 @@ event bro_init() &priority=-5
 {
 	for (stream_id in Log::active_streams)
 	{
-		if (stream_id in Kafka::logs_to_send)
+		if ( (|logs_to_send| == 0) || stream_id in Kafka::logs_to_send )
 		{
 			local filter: Log::Filter = [
 				$name = fmt("kafka-%s", stream_id),

--- a/scripts/init.bro
+++ b/scripts/init.bro
@@ -21,6 +21,7 @@ export {
   const topic_name: string = "bro" &redef;
   const max_wait_on_shutdown: count = 3000 &redef;
   const tag_json: bool = F &redef;
+  const json_timestamps: JSON::TimestampFormat = JSON::TS_EPOCH &redef;
   const kafka_conf: table[string] of string = table(
     ["metadata.broker.list"] = "localhost:9092"
   ) &redef;

--- a/src/KafkaWriter.cc
+++ b/src/KafkaWriter.cc
@@ -84,7 +84,7 @@ bool KafkaWriter::DoInit(const WriterInfo& info, int num_fields, const threading
     else
     {
       Error(Fmt("KafkaWriter::DoInit: Invalid JSON timestamp format %s",
-        json_timestamps.cstr()));
+        json_timestamps.c_str()));
       return false;
     }
 

--- a/src/KafkaWriter.h
+++ b/src/KafkaWriter.h
@@ -68,6 +68,7 @@ private:
     static const string default_topic_key;
     string stream_id;
     bool tag_json;
+    string json_timestamps;
     map<string, string> kafka_conf;
     string topic_name;
     threading::formatter::Formatter *formatter;

--- a/src/KafkaWriter.h
+++ b/src/KafkaWriter.h
@@ -47,7 +47,7 @@ namespace logging { namespace writer {
 class KafkaWriter : public WriterBackend {
 
 public:
-    KafkaWriter(WriterFrontend* frontend);
+    explicit KafkaWriter(WriterFrontend* frontend);
     ~KafkaWriter();
 
     static WriterBackend* Instantiate(WriterFrontend* frontend)

--- a/src/kafka.bif
+++ b/src/kafka.bif
@@ -21,4 +21,5 @@ const kafka_conf: config;
 const topic_name: string;
 const max_wait_on_shutdown: count;
 const tag_json: bool;
+const json_timestamps: JSON::TimestampFormat;
 const debug: string;


### PR DESCRIPTION
I added the ability to format timestamps using the same convention as the ASCII writer. It still defaults to the JSON::TS_EPOCH. When doing JSON output, I have better luck across myriad of time parsers to use the ISO8601 format. Namely, I've run into parsers that otherwise won't preserve the microsecond precision of the timestamp.

I also changed the behavior of `logs_to_send` to send all logs by default, if none are specified.